### PR TITLE
it's typo fix

### DIFF
--- a/content/2020-12-09-rust-and-async.md
+++ b/content/2020-12-09-rust-and-async.md
@@ -22,7 +22,7 @@ is theirs, just sometimes (while other threads are running), it's just a very
 slow processor.
 
 To accomplish this magic of appearing to own the entire processor, threads
-also have to actually give each thread it's own space for it's stack 
+also have to actually give each thread its own space for its stack 
 to grow. Additionally, the kernel has to occasionally freeze one thread, swap
 out that thread's stack for another waiting thread's, and then unfreeze the other 
 thread to run for a bit. This is _context switching_.


### PR DESCRIPTION
"It's" can only be a contraction of "it is" or "it has". "it's stack" is neither so no apostrophe. "its" is already the possessive pronoun, just as you don't write "I like hi's code." :wink:

(I meant to submit this trivial PR years ago but lost it.)